### PR TITLE
Docs: Update preset documentation to reflect actual presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,11 +93,12 @@ claude-worktree/
 - **`cw config set <key> <value>`**: Set configuration value
 - **`cw config use-preset <name>`**: Use predefined AI tool preset
   - Available presets:
+    - `no-op`: Disable AI tool launching
     - `claude`: Claude Code (default)
     - `codex`: OpenAI Codex
     - `happy`: Happy with Claude Code (mobile-enabled)
-    - `happy-codex`: Happy with Codex mode
-    - `happy-sonnet`, `happy-opus`, `happy-haiku`: Happy with model selection
+    - `happy-codex`: Happy with Codex mode and bypass permissions
+    - `happy-yolo`: Happy with YOLO mode (bypass all permissions)
 - **`cw config list-presets`**: List available presets
 - **`cw config reset`**: Reset to defaults
 - Configuration stored in `~/.config/claude-worktree/config.json`

--- a/README.md
+++ b/README.md
@@ -207,13 +207,12 @@ cw config set ai-tool codex
 cw config set ai-tool "happy --backend claude"
 
 # Use a predefined preset
-cw config use-preset claude
-cw config use-preset codex
-cw config use-preset happy
-cw config use-preset happy-codex
-cw config use-preset happy-sonnet
-cw config use-preset happy-opus
-cw config use-preset happy-haiku
+cw config use-preset claude         # Claude Code (default)
+cw config use-preset codex          # OpenAI Codex
+cw config use-preset happy          # Happy with Claude Code
+cw config use-preset happy-codex    # Happy with Codex mode
+cw config use-preset happy-yolo     # Happy with bypass all permissions
+cw config use-preset no-op          # Disable AI tool launch
 
 # List available presets
 cw config list-presets
@@ -257,15 +256,19 @@ cw new my-feature
 # QR code will appear for mobile connection
 ```
 
-#### Model Selection
+#### Permission Modes
+
+Happy supports different permission modes for faster iteration:
 
 ```bash
-# Use specific Claude model
-cw config use-preset happy-opus
-cw new my-feature
+# Standard mode (default)
+cw config use-preset happy
 
-# Or customize directly
-cw config set ai-tool "happy -m sonnet"
+# Codex mode with bypass permissions
+cw config use-preset happy-codex
+
+# YOLO mode - bypass all permissions (fastest, use in sandboxes)
+cw config use-preset happy-yolo
 ```
 
 #### Using Happy with Codex


### PR DESCRIPTION
## Summary
Removed references to non-existent presets and documented the actual available presets across CLAUDE.md and README.md.

## Changes

### CLAUDE.md
- ✅ Added: `no-op`, `happy-yolo` to preset list
- ❌ Removed: `happy-sonnet`, `happy-opus`, `happy-haiku` (never implemented)
- ✅ Added descriptions for each preset

### README.md
- ✅ Updated preset examples with inline comments
- ✅ Changed "Model Selection" section to "Permission Modes" for Happy
- ✅ Documented all 6 actual presets: `no-op`, `claude`, `codex`, `happy`, `happy-codex`, `happy-yolo`
- ❌ Removed non-existent model-specific presets

## Actual Available Presets
From `src/claude_worktree/config.py:23-34`:
- `no-op`: Disable AI tool launching  
- `claude`: Claude Code (default)
- `codex`: OpenAI Codex
- `happy`: Happy with Claude Code
- `happy-codex`: Happy with Codex mode and bypass permissions
- `happy-yolo`: Happy with YOLO mode (bypass all permissions)

## Why
The model-specific presets (`happy-sonnet`, `happy-opus`, `happy-haiku`) were documented in CHANGELOG v0.6.2 and mentioned in README/CLAUDE.md, but were never actually implemented in the code. They were removed in v0.7.0 according to CHANGELOG.

## Related
Fixes TODO.md: "Update preset documentation across all files"