### PR TITLE
Feat: Add configurable auto-update check setting

### DIFF
--- a/src/claude_worktree/config.py
+++ b/src/claude_worktree/config.py
@@ -46,6 +46,9 @@ DEFAULT_CONFIG = {
     "git": {
         "default_base_branch": "main",
     },
+    "update": {
+        "auto_check": True,  # Automatically check for updates daily
+    },
 }
 
 

--- a/src/claude_worktree/update.py
+++ b/src/claude_worktree/update.py
@@ -287,12 +287,21 @@ def check_for_updates(auto: bool = True) -> bool:
     Check for updates and optionally prompt user to upgrade.
 
     Args:
-        auto: If True, only check if it's the first run today.
+        auto: If True, only check if it's the first run today and auto-check is enabled.
               If False, always check (for manual upgrade command)
 
     Returns:
         True if an update is available, False otherwise
     """
+    # For auto-check, respect the config setting
+    if auto:
+        from .config import load_config
+
+        config = load_config()
+        if not config.get("update", {}).get("auto_check", True):
+            # Auto-check is disabled
+            return False
+
     # Show current version for manual upgrade
     current_version = __version__
     if not auto:


### PR DESCRIPTION
## Summary
Added `update.auto_check` configuration option to allow users to control automatic daily update checks.

## Changes

### config.py
- Added `update.auto_check: True` to `DEFAULT_CONFIG`
- Default is `True` (preserves existing behavior)
- Users can modify with standard config commands

### update.py  
- Modified `check_for_updates()` to check config before auto-updating
- Early return if `auto_check` is disabled (when `auto=True`)
- Manual `cw upgrade` always works regardless of setting

## Usage

```bash
# Disable automatic update checks
cw config set update.auto_check false

# Re-enable automatic update checks
cw config set update.auto_check true

# Manual upgrade always works
cw upgrade
```

## Use Cases
- **Corporate environments**: Restricted internet access or controlled update cycles
- **Air-gapped systems**: No internet connectivity  
- **Manual control**: Users who prefer explicit update control
- **CI/CD environments**: Controlled dependency versions

## Testing
- ✅ All existing config tests pass (27/27)
- ✅ Config merging properly handles new `update.auto_check` field
- ✅ Default behavior unchanged (`auto_check` defaults to `true`)
- ✅ Backward compatible with existing configs

## Related
Implements TODO.md: "Configurable auto-update behavior"