### PR TITLE
feat: Add --interactive/-i flag to cw finish command

### DIFF
--- a/src/claude_worktree/cli.py
+++ b/src/claude_worktree/cli.py
@@ -184,6 +184,12 @@ def finish(
         "--push",
         help="Push base branch to origin after merge",
     ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Pause for confirmation before each step",
+    ),
 ) -> None:
     """
     Finish work on a worktree.
@@ -198,13 +204,16 @@ def finish(
     Can be run from any directory by specifying the worktree branch name,
     or from within a feature worktree without arguments.
 
+    Use --interactive/-i to confirm each step before execution.
+
     Example:
         cw finish                  # Finish current worktree
         cw finish fix-auth         # Finish fix-auth worktree from anywhere
         cw finish feature-api --push  # Finish and push to remote
+        cw finish -i               # Interactive mode with confirmations
     """
     try:
-        finish_worktree(target=target, push=push)
+        finish_worktree(target=target, push=push, interactive=interactive)
     except ClaudeWorktreeError as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         raise typer.Exit(code=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -321,3 +321,25 @@ def test_cd_command_nonexistent_branch(temp_git_repo: Path) -> None:
     result = runner.invoke(app, ["cd", "nonexistent-branch"])
     assert result.exit_code != 0
     assert "Error" in result.stdout
+
+
+def test_finish_command_interactive_flag(temp_git_repo: Path, disable_claude) -> None:
+    """Test finish command accepts --interactive flag."""
+    # Create worktree
+    runner.invoke(app, ["new", "interactive-test", "--no-cd"])
+
+    # Test that --interactive flag is accepted (we can't test interactive input in unit tests)
+    result = runner.invoke(app, ["finish", "--help"])
+    assert result.exit_code == 0
+    assert "--interactive" in result.stdout or "-i" in result.stdout
+
+    # Clean up
+    runner.invoke(app, ["delete", "interactive-test"])
+
+
+def test_finish_command_short_interactive_flag(temp_git_repo: Path, disable_claude) -> None:
+    """Test finish command accepts -i short flag."""
+    result = runner.invoke(app, ["finish", "--help"])
+    assert result.exit_code == 0
+    assert "-i" in result.stdout
+    assert "Pause for confirmation" in result.stdout


### PR DESCRIPTION
## Summary

Implements interactive mode for the `cw finish` command, allowing users to pause and confirm each step before execution.

**Features:**
- `cw finish -i` or `cw finish --interactive`: Step-by-step confirmations
- Prompts before: rebase, merge, push (if `--push`), and cleanup
- User can skip steps (`n`) or abort entirely (`q`)
- Non-interactive mode remains default for automation

## Interactive Prompts

1. **Rebase feature onto base** - Confirm before rebasing
2. **Merge feature into base** - Confirm before merge  
3. **Push base to origin** - Confirm before push (if `--push` flag used)
4. **Clean up worktree and delete branch** - Confirm before cleanup

Each prompt allows:
- `Y`/`yes`/Enter: Continue with step
- `N`/`no`: Skip this step and subsequent steps
- `Q`/`quit`: Abort the entire finish operation

## Use Case

Provides safety for irreversible operations like deleting branches and allows users to review changes at each stage before proceeding. Particularly useful for:
- First-time users learning the workflow
- Critical branches requiring extra caution
- Situations where you want to review each step

## Changes

- Updated `src/claude_worktree/cli.py` to add `--interactive/-i` flag
- Updated `src/claude_worktree/core.py:finish_worktree()` with interactive prompts
- Added 2 test cases in `tests/test_cli.py`

## Test Plan

- [x] `cw finish --help` - Shows interactive flag documentation
- [x] `cw finish -i` - Short flag works
- [x] Help text includes "Pause for confirmation" description
- [x] Code passes ruff and mypy checks
- [x] Pre-commit hooks pass

## Related

Closes medium priority item from TODO.md: "Add `cw finish --interactive` for step-by-step merge confirmation"