### PR TITLE
feat: Add cw clean command for batch worktree cleanup

### DIFF
--- a/src/claude_worktree/cli.py
+++ b/src/claude_worktree/cli.py
@@ -324,6 +324,64 @@ def prune() -> None:
 
 
 @app.command()
+def clean(
+    merged: bool = typer.Option(
+        False,
+        "--merged",
+        help="Delete worktrees for branches already merged to base",
+    ),
+    stale: bool = typer.Option(
+        False,
+        "--stale",
+        help="Delete worktrees with 'stale' status",
+    ),
+    older_than: int | None = typer.Option(
+        None,
+        "--older-than",
+        help="Delete worktrees older than N days",
+        metavar="DAYS",
+    ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Interactive selection UI",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be deleted without actually deleting",
+    ),
+) -> None:
+    """
+    Batch cleanup of worktrees.
+
+    Delete multiple worktrees based on various criteria. Use --dry-run
+    to preview what would be deleted before actually removing anything.
+
+    Example:
+        cw clean --merged           # Delete merged worktrees
+        cw clean --stale            # Delete stale worktrees
+        cw clean --older-than 30    # Delete worktrees older than 30 days
+        cw clean -i                 # Interactive selection
+        cw clean --merged --dry-run # Preview merged worktrees
+    """
+    try:
+        from .core import clean_worktrees
+
+        clean_worktrees(
+            merged=merged,
+            stale=stale,
+            older_than=older_than,
+            interactive=interactive,
+            dry_run=dry_run,
+        )
+    except ClaudeWorktreeError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@app.command()
 def delete(
     target: str = typer.Argument(
         ...,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,3 +361,22 @@ def test_sync_command_accepts_flags(temp_git_repo: Path, disable_claude) -> None
     assert (
         "fetch" in result.stdout and "only" in result.stdout and "without rebasing" in result.stdout
     )
+
+
+def test_clean_command_help(temp_git_repo: Path) -> None:
+    """Test clean command help."""
+    result = runner.invoke(app, ["clean", "--help"])
+    assert result.exit_code == 0
+    assert "Batch cleanup of worktrees" in result.stdout
+
+
+def test_clean_command_accepts_flags(temp_git_repo: Path, disable_claude) -> None:
+    """Test clean command accepts all flags."""
+    result = runner.invoke(app, ["clean", "--help"])
+    assert result.exit_code == 0
+    # Check for flag names (ANSI codes may be present in colored output)
+    assert "merged" in result.stdout and "branches already merged" in result.stdout
+    assert "stale" in result.stdout and "stale" in result.stdout.lower()
+    assert "older" in result.stdout and "than" in result.stdout and "days" in result.stdout
+    assert "interactive" in result.stdout.lower() or "-i" in result.stdout
+    assert "dry" in result.stdout and "run" in result.stdout


### PR DESCRIPTION
## Summary

Implements `cw clean` command for intelligent batch deletion of worktrees. Essential for maintaining a clean workspace by removing completed, abandoned, or stale worktrees.

**Features:**
- `cw clean --merged` - Delete worktrees for branches already merged to base
- `cw clean --stale` - Delete worktrees with stale status (directory missing)
- `cw clean --older-than N` - Delete worktrees older than N days
- `cw clean -i/--interactive` - Interactive selection UI
- `cw clean --dry-run` - Preview what would be deleted

## Behavior

1. **Multiple criteria**: Can combine flags (e.g., `--merged --stale`)
2. **Detailed information**: Shows branch name, reason, and path for each worktree
3. **Confirmation prompt**: Required for large batch deletions (>3 worktrees)
4. **Interactive mode**: Lists all worktrees with status for manual selection
5. **Dry-run preview**: See what would happen without actually deleting
6. **Error handling**: Gracefully continues with remaining worktrees if one fails

## Safety Features

- **Requires criteria**: Prevents accidental mass deletion
- **Confirmation prompts**: Extra safety for large batches
- **Dry-run capability**: Preview before executing
- **Per-worktree errors**: One failure doesn't stop entire cleanup

## Use Cases

- Clean up after completing and merging multiple features
- Remove abandoned experimental branches
- Delete old worktrees not touched in weeks/months
- Periodic workspace maintenance
- Free up disk space from accumulated worktrees

## Example Workflows

```bash
# Preview what would be deleted
cw clean --merged --dry-run

# Delete all merged worktrees
cw clean --merged

# Delete stale worktrees (directories that no longer exist)
cw clean --stale

# Delete worktrees older than 30 days
cw clean --older-than 30

# Combine criteria
cw clean --merged --older-than 14

# Interactive selection
cw clean -i
# > Enter branch names: feature-1 feature-2 old-experiment

# Delete all worktrees (interactive with "all")
cw clean -i
# > all
```

## Changes

- Added `clean` command in `src/claude_worktree/cli.py:310-366`
- Implemented `clean_worktrees()` in `src/claude_worktree/core.py:368-532`
- Added 2 test cases in `tests/test_cli.py`

## Test Plan

- [x] `cw clean --help` - Shows all options
- [x] `cw clean --merged` - Deletes merged worktrees
- [x] `cw clean --stale` - Deletes stale worktrees
- [x] `cw clean --older-than N` - Deletes old worktrees
- [x] `cw clean -i` - Interactive selection works
- [x] `cw clean --dry-run` - Preview without deleting
- [x] Code passes ruff and mypy checks
- [x] Pre-commit hooks pass

## Related

Closes medium priority item from TODO.md: "Add `cw clean` command for batch cleanup"