### PR TITLE
feat: Add cw doctor command for worktree health check

### DIFF
--- a/src/claude_worktree/cli.py
+++ b/src/claude_worktree/cli.py
@@ -478,6 +478,31 @@ def sync(
 
 
 @app.command()
+def doctor() -> None:
+    """
+    Perform health check on all worktrees.
+
+    Checks for common issues and provides recommendations:
+    - Git version compatibility (minimum 2.31.0)
+    - Worktree accessibility (detects stale worktrees)
+    - Uncommitted changes in worktrees
+    - Worktrees behind their base branch
+    - Existing merge conflicts
+    - Cleanup recommendations
+
+    Example:
+        cw doctor    # Run full health check
+    """
+    try:
+        from .core import doctor as run_doctor
+
+        run_doctor()
+    except ClaudeWorktreeError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@app.command()
 def upgrade() -> None:
     """
     Upgrade claude-worktree to the latest version.

--- a/src/claude_worktree/core.py
+++ b/src/claude_worktree/core.py
@@ -758,6 +758,249 @@ def clean_worktrees(
     )
 
 
+def doctor() -> None:
+    """
+    Perform health check on all worktrees.
+
+    Checks:
+    - Git version compatibility
+    - Worktree accessibility
+    - Uncommitted changes
+    - Worktrees behind base branch
+    - Existing merge conflicts
+    - Cleanup recommendations
+    """
+    import subprocess
+
+    from packaging.version import parse
+
+    repo = get_repo_root()
+    console.print("\n[bold cyan]🏥 claude-worktree Health Check[/bold cyan]\n")
+
+    issues_found = 0
+    warnings_found = 0
+
+    # 1. Check Git version
+    console.print("[bold]1. Checking Git version...[/bold]")
+    try:
+        result = subprocess.run(
+            ["git", "--version"], capture_output=True, text=True, check=True, timeout=5
+        )
+        version_output = result.stdout.strip()
+        # Extract version number (e.g., "git version 2.39.0" -> "2.39.0")
+        version_str = version_output.split()[-1]
+        git_version = parse(version_str)
+        min_version = parse("2.31.0")
+
+        if git_version >= min_version:
+            console.print(f"   [green]✓[/green] Git version {version_str} (minimum: 2.31.0)")
+        else:
+            console.print(f"   [red]✗[/red] Git version {version_str} is too old (minimum: 2.31.0)")
+            issues_found += 1
+    except Exception as e:
+        console.print(f"   [red]✗[/red] Could not detect Git version: {e}")
+        issues_found += 1
+
+    console.print()
+
+    # 2. Check all worktrees
+    console.print("[bold]2. Checking worktree accessibility...[/bold]")
+    worktrees: list[tuple[str, Path, str]] = []
+    stale_count = 0
+    for branch, path in parse_worktrees(repo):
+        # Skip main repository
+        if str(Path(path).resolve()) == str(repo.resolve()):
+            continue
+        if branch == "(detached)":
+            continue
+
+        branch_name = branch[11:] if branch.startswith("refs/heads/") else branch
+        status = get_worktree_status(path, repo)
+        worktrees.append((branch_name, Path(path), status))
+
+        if status == "stale":
+            stale_count += 1
+            console.print(f"   [red]✗[/red] {branch_name}: Stale (directory missing)")
+            issues_found += 1
+
+    if stale_count == 0:
+        console.print(f"   [green]✓[/green] All {len(worktrees)} worktrees are accessible")
+    else:
+        console.print(
+            f"   [yellow]⚠[/yellow] {stale_count} stale worktree(s) found (use 'cw prune')"
+        )
+
+    console.print()
+
+    # 3. Check for uncommitted changes
+    console.print("[bold]3. Checking for uncommitted changes...[/bold]")
+    dirty_worktrees: list[tuple[str, Path]] = []
+    for branch_name, path, status in worktrees:  # type: ignore[assignment]
+        if status in ["modified", "active"]:
+            # Check if there are actual uncommitted changes
+            try:
+                diff_result = git_command(
+                    "status",
+                    "--porcelain",
+                    repo=path,  # type: ignore[arg-type]
+                    capture=True,
+                    check=False,
+                )
+                if diff_result.returncode == 0 and diff_result.stdout.strip():
+                    dirty_worktrees.append((branch_name, path))  # type: ignore[arg-type]
+            except Exception:
+                pass
+
+    if dirty_worktrees:
+        console.print(
+            f"   [yellow]⚠[/yellow] {len(dirty_worktrees)} worktree(s) with uncommitted changes:"
+        )
+        for branch_name, _path in dirty_worktrees:
+            console.print(f"      • {branch_name}")
+        warnings_found += 1
+    else:
+        console.print("   [green]✓[/green] No uncommitted changes")
+
+    console.print()
+
+    # 4. Check if worktrees are behind base branch
+    console.print("[bold]4. Checking if worktrees are behind base branch...[/bold]")
+    behind_worktrees: list[tuple[str, str, str]] = []
+    for branch_name, path, status in worktrees:  # type: ignore[assignment]
+        if status == "stale":
+            continue
+
+        # Get base branch metadata
+        base_branch = get_config(CONFIG_KEY_BASE_BRANCH.format(branch_name), repo)
+        if not base_branch:
+            continue
+
+        try:
+            # Fetch to get latest remote refs
+            git_command("fetch", "--all", "--prune", repo=path, check=False)  # type: ignore[arg-type]
+
+            # Check if branch is behind origin/base
+            merge_base_result = git_command(
+                "merge-base",
+                branch_name,
+                f"origin/{base_branch}",
+                repo=path,  # type: ignore[arg-type]
+                capture=True,
+                check=False,
+            )
+            if merge_base_result.returncode != 0:
+                continue
+
+            merge_base = merge_base_result.stdout.strip()
+
+            # Get current commit of base branch
+            base_commit_result = git_command(
+                "rev-parse",
+                f"origin/{base_branch}",
+                repo=path,  # type: ignore[arg-type]
+                capture=True,
+                check=False,
+            )
+            if base_commit_result.returncode != 0:
+                continue
+
+            base_commit = base_commit_result.stdout.strip()
+
+            # If merge base != base commit, then we're behind
+            if merge_base != base_commit:
+                # Count commits behind
+                behind_count_result = git_command(
+                    "rev-list",
+                    "--count",
+                    f"{branch_name}..origin/{base_branch}",
+                    repo=path,  # type: ignore[arg-type]
+                    capture=True,
+                    check=False,
+                )
+                if behind_count_result.returncode == 0:
+                    behind_count = behind_count_result.stdout.strip()
+                    behind_worktrees.append((branch_name, base_branch, behind_count))
+        except Exception:
+            pass
+
+    if behind_worktrees:
+        console.print(
+            f"   [yellow]⚠[/yellow] {len(behind_worktrees)} worktree(s) behind base branch:"
+        )
+        for branch_name, base_branch, count in behind_worktrees:
+            console.print(f"      • {branch_name}: {count} commit(s) behind {base_branch}")
+        console.print("   [dim]Tip: Use 'cw sync --all' to update all worktrees[/dim]")
+        warnings_found += 1
+    else:
+        console.print("   [green]✓[/green] All worktrees are up-to-date with base")
+
+    console.print()
+
+    # 5. Check for existing merge conflicts
+    console.print("[bold]5. Checking for merge conflicts...[/bold]")
+    conflicted_worktrees: list[tuple[str, list[str]]] = []
+    for branch_name, path, status in worktrees:  # type: ignore[assignment]
+        if status == "stale":
+            continue
+
+        try:
+            # Check for unmerged files (conflicts)
+            conflicts_result = git_command(
+                "diff",
+                "--name-only",
+                "--diff-filter=U",
+                repo=path,  # type: ignore[arg-type]
+                capture=True,
+                check=False,
+            )
+            if conflicts_result.returncode == 0 and conflicts_result.stdout.strip():
+                conflicted_files = conflicts_result.stdout.strip().splitlines()
+                conflicted_worktrees.append((branch_name, conflicted_files))
+        except Exception:
+            pass
+
+    if conflicted_worktrees:
+        console.print(
+            f"   [red]✗[/red] {len(conflicted_worktrees)} worktree(s) with merge conflicts:"
+        )
+        for branch_name, files in conflicted_worktrees:
+            console.print(f"      • {branch_name}: {len(files)} conflicted file(s)")
+        console.print("   [dim]Tip: Use 'cw finish --ai-merge' for AI-assisted resolution[/dim]")
+        issues_found += 1
+    else:
+        console.print("   [green]✓[/green] No merge conflicts detected")
+
+    console.print()
+
+    # Summary
+    console.print("[bold cyan]Summary:[/bold cyan]")
+    if issues_found == 0 and warnings_found == 0:
+        console.print("[bold green]✓ Everything looks healthy![/bold green]\n")
+    else:
+        if issues_found > 0:
+            console.print(f"[bold red]✗ {issues_found} issue(s) found[/bold red]")
+        if warnings_found > 0:
+            console.print(f"[bold yellow]⚠ {warnings_found} warning(s) found[/bold yellow]")
+        console.print()
+
+    # Recommendations
+    if stale_count > 0:
+        console.print("[bold]Recommendations:[/bold]")
+        console.print("  • Run [cyan]cw prune[/cyan] to clean up stale worktrees")
+    if behind_worktrees:
+        if not stale_count:
+            console.print("[bold]Recommendations:[/bold]")
+        console.print("  • Run [cyan]cw sync --all[/cyan] to update all worktrees")
+    if conflicted_worktrees:
+        if not stale_count and not behind_worktrees:
+            console.print("[bold]Recommendations:[/bold]")
+        console.print("  • Resolve conflicts in conflicted worktrees")
+        console.print("  • Use [cyan]cw finish --ai-merge[/cyan] for AI assistance")
+
+    if stale_count > 0 or behind_worktrees or conflicted_worktrees:
+        console.print()
+
+
 def get_worktree_status(path: str, repo: Path) -> str:
     """
     Determine the status of a worktree.


### PR DESCRIPTION
## Summary
Implements `cw doctor` command - a comprehensive health check utility for diagnosing worktree issues.

## Features
- **Git Version Check**: Verifies Git >= 2.31.0 (required for modern worktree support)
- **Worktree Accessibility**: Detects stale worktrees (directories that no longer exist)
- **Uncommitted Changes**: Identifies worktrees with uncommitted work
- **Behind Base Branch**: Checks if worktrees are out of sync with their base branches
- **Merge Conflicts**: Detects existing conflicts in worktrees
- **Automated Recommendations**: Suggests appropriate fix commands (`cw prune`, `cw sync --all`, `cw finish --ai-merge`)

## Implementation Details
- Added `doctor()` function in `src/claude_worktree/core.py` (lines 761-1001)
- Added `doctor` command in `src/claude_worktree/cli.py`
- Uses packaging.version for Git version comparison
- Iterates through all worktrees with 5 distinct health checks
- Provides color-coded output (green ✓, yellow ⚠, red ✗)
- Counts issues and warnings separately

## Output Example
```
🏥 claude-worktree Health Check

1. Checking Git version...
   ✓ Git version 2.39.3 (minimum: 2.31.0)

2. Checking worktree accessibility...
   ✓ All 3 worktrees are accessible

3. Checking for uncommitted changes...
   ⚠ 1 worktree(s) with uncommitted changes:
      • feature/new-ui

4. Checking if worktrees are behind base branch...
   ⚠ 2 worktree(s) behind base branch:
      • feature/api: 3 commit(s) behind main
      • fix/bug-123: 1 commit(s) behind main
   Tip: Use 'cw sync --all' to update all worktrees

5. Checking for merge conflicts...
   ✓ No merge conflicts detected

Summary:
⚠ 2 warning(s) found

Recommendations:
  • Run cw sync --all to update all worktrees
```

## Type Safety
All mypy strict type checks pass with appropriate type: ignore comments for known limitations in parse_worktrees return type.

## Priority
Implements MEDIUM priority task from TODO.md.

## Test plan
- [x] Verify command appears in `cw --help`
- [ ] Run `cw doctor` in repository with clean worktrees
- [ ] Run `cw doctor` with stale worktrees (verify detection)
- [ ] Run `cw doctor` with uncommitted changes (verify detection)
- [ ] Run `cw doctor` with worktrees behind base (verify detection)
- [ ] Run `cw doctor` with merge conflicts (verify detection)
- [ ] Verify recommendations appear appropriately
- [ ] Verify GitHub Actions tests pass