### PR TITLE
feat: Add cw stash command for worktree-aware stash management

### DIFF
--- a/src/claude_worktree/cli.py
+++ b/src/claude_worktree/cli.py
@@ -869,5 +869,93 @@ def reset() -> None:
         raise typer.Exit(code=1)
 
 
+# Stash commands
+stash_app = typer.Typer(
+    name="stash",
+    help="Worktree-aware stash management",
+    no_args_is_help=True,
+)
+app.add_typer(stash_app, name="stash")
+
+
+@stash_app.command(name="save")
+def stash_save_cmd(
+    message: str | None = typer.Argument(
+        None,
+        help="Optional message to describe the stash",
+    ),
+) -> None:
+    """
+    Save changes in current worktree to stash.
+
+    Creates a stash with a branch-prefixed message to help organize
+    stashes by worktree. If no message is provided, uses "WIP" as default.
+
+    Example:
+        cw stash save                  # Stash with default "WIP" message
+        cw stash save "work in progress"  # Stash with custom message
+    """
+    try:
+        from .core import stash_save
+
+        stash_save(message=message)
+    except ClaudeWorktreeError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@stash_app.command(name="list")
+def stash_list_cmd() -> None:
+    """
+    List all stashes organized by worktree/branch.
+
+    Shows all stashes grouped by the branch they were created from,
+    making it easy to see which stashes belong to which worktree.
+
+    Example:
+        cw stash list
+    """
+    try:
+        from .core import stash_list
+
+        stash_list()
+    except ClaudeWorktreeError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@stash_app.command(name="apply")
+def stash_apply_cmd(
+    target_branch: str = typer.Argument(
+        ...,
+        help="Branch name of worktree to apply stash to",
+        autocompletion=complete_worktree_branches,
+    ),
+    stash_ref: str = typer.Option(
+        "stash@{0}",
+        "--stash",
+        "-s",
+        help="Stash reference (default: stash@{0} - most recent)",
+    ),
+) -> None:
+    """
+    Apply a stash to a different worktree.
+
+    Applies the specified stash (or most recent by default) to the
+    target worktree. This allows moving changes between worktrees.
+
+    Example:
+        cw stash apply fix-auth              # Apply most recent stash to fix-auth
+        cw stash apply feature-api --stash stash@{1}  # Apply specific stash
+    """
+    try:
+        from .core import stash_apply
+
+        stash_apply(target_branch=target_branch, stash_ref=stash_ref)
+    except ClaudeWorktreeError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
 if __name__ == "__main__":
     app()

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -129,7 +129,7 @@ def test_find_worktree_by_branch(temp_git_repo: Path) -> None:
 
     # Should find the worktree
     found_path = find_worktree_by_branch(temp_git_repo, "refs/heads/my-feature")
-    assert found_path == str(feature_path)
+    assert found_path == feature_path
 
     # Should not find non-existent branch
     assert find_worktree_by_branch(temp_git_repo, "refs/heads/nonexistent") is None

--- a/tests/test_stash.py
+++ b/tests/test_stash.py
@@ -1,0 +1,237 @@
+"""Tests for stash functionality."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from claude_worktree.core import stash_apply, stash_list, stash_save
+from claude_worktree.exceptions import GitError, WorktreeNotFoundError
+
+
+def test_stash_save_with_message(temp_git_repo: Path, monkeypatch) -> None:
+    """Test saving stash with custom message."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create a file to stash
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("test content")
+
+    # Save stash with message
+    stash_save(message="my custom message")
+
+    # Verify stash was created
+    result = subprocess.run(
+        ["git", "stash", "list"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Check stash message includes branch and custom message
+    branch_name = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    assert f"[{branch_name}] my custom message" in result.stdout
+
+    # Verify working directory is clean
+    assert not test_file.exists()
+
+
+def test_stash_save_without_message(temp_git_repo: Path, monkeypatch) -> None:
+    """Test saving stash with default WIP message."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create a file to stash
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("test content")
+
+    # Save stash without message
+    stash_save()
+
+    # Verify stash was created with default message
+    result = subprocess.run(
+        ["git", "stash", "list"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    branch_name = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    assert f"[{branch_name}] WIP" in result.stdout
+
+
+def test_stash_save_no_changes(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test stash save when there are no changes."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Try to stash with no changes
+    stash_save()
+
+    # Should print warning
+    captured = capsys.readouterr()
+    assert "No changes to stash" in captured.out
+
+
+def test_stash_list_empty(temp_git_repo: Path, capsys) -> None:
+    """Test listing stashes when none exist."""
+    stash_list()
+
+    captured = capsys.readouterr()
+    assert "No stashes found" in captured.out
+
+
+def test_stash_list_multiple_branches(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test listing stashes from multiple branches."""
+    # Create stash on main branch
+    monkeypatch.chdir(temp_git_repo)
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("main content")
+    stash_save(message="main work")
+
+    # Create a new branch and stash
+    subprocess.run(
+        ["git", "checkout", "-b", "feature"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    test_file2 = temp_git_repo / "test2.txt"
+    test_file2.write_text("feature content")
+    stash_save(message="feature work")
+
+    # List stashes
+    stash_list()
+
+    captured = capsys.readouterr()
+    # Should show both branches
+    assert "main" in captured.out or "master" in captured.out
+    assert "feature" in captured.out
+    assert "main work" in captured.out
+    assert "feature work" in captured.out
+
+
+def test_stash_apply_to_same_worktree(temp_git_repo: Path, monkeypatch) -> None:
+    """Test applying stash to the same worktree."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create and stash a file
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("test content")
+
+    branch_name = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    stash_save(message="my work")
+
+    # File should be gone
+    assert not test_file.exists()
+
+    # Apply stash back
+    stash_apply(target_branch=branch_name)
+
+    # File should be restored
+    assert test_file.exists()
+    assert test_file.read_text() == "test content"
+
+
+def test_stash_apply_to_different_worktree(temp_git_repo: Path, monkeypatch) -> None:
+    """Test applying stash to a different worktree."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create and stash a file on main
+    test_file = temp_git_repo / "test.txt"
+    test_file.write_text("main content")
+    stash_save(message="main work")
+
+    # Create a new worktree
+    feature_path = temp_git_repo.parent / "feature"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-branch", str(feature_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    # Apply stash to the new worktree
+    stash_apply(target_branch="refs/heads/feature-branch")
+
+    # Verify file exists in feature worktree
+    feature_test_file = feature_path / "test.txt"
+    assert feature_test_file.exists()
+    assert feature_test_file.read_text() == "main content"
+
+
+def test_stash_apply_nonexistent_branch(temp_git_repo: Path) -> None:
+    """Test applying stash to nonexistent branch."""
+    with pytest.raises(WorktreeNotFoundError, match="No worktree found for branch"):
+        stash_apply(target_branch="nonexistent-branch")
+
+
+def test_stash_apply_invalid_stash_ref(temp_git_repo: Path, monkeypatch) -> None:
+    """Test applying invalid stash reference."""
+    monkeypatch.chdir(temp_git_repo)
+
+    branch_name = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    with pytest.raises(GitError, match="Stash .* not found"):
+        stash_apply(target_branch=branch_name, stash_ref="stash@{999}")
+
+
+def test_stash_apply_specific_ref(temp_git_repo: Path, monkeypatch) -> None:
+    """Test applying a specific stash by reference."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create multiple stashes
+    test_file1 = temp_git_repo / "test1.txt"
+    test_file1.write_text("first")
+    stash_save(message="first stash")
+
+    test_file2 = temp_git_repo / "test2.txt"
+    test_file2.write_text("second")
+    stash_save(message="second stash")
+
+    # Both files should be gone
+    assert not test_file1.exists()
+    assert not test_file2.exists()
+
+    branch_name = subprocess.run(
+        ["git", "branch", "--show-current"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    # Apply the older stash (stash@{1})
+    stash_apply(target_branch=branch_name, stash_ref="stash@{1}")
+
+    # Only first file should be restored
+    assert test_file1.exists()
+    assert not test_file2.exists()


### PR DESCRIPTION
## Summary

Implements worktree-aware stash management with three subcommands:
- **`cw stash save [message]`**: Save changes with branch-prefixed messages
- **`cw stash list`**: List stashes organized by branch
- **`cw stash apply <target-branch> [--stash <ref>]`**: Apply stashes to different worktrees

## Key Features

- Automatically prefixes stash messages with `[branch-name]` for easy identification
- Organizes stash listings by branch for better visibility
- Supports cross-worktree stash application
- Includes untracked files in stashes (`--include-untracked` flag)
- Comprehensive error handling with helpful messages

## Implementation Details

### Core Functions (src/claude_worktree/core.py)
1. **`stash_save(message)`**: Creates a stash with branch prefix
2. **`stash_list()`**: Parses and displays stashes grouped by branch
3. **`stash_apply(target_branch, stash_ref)`**: Applies stash to specified worktree

### CLI Commands (src/claude_worktree/cli.py)
- Added `stash` subcommand group with three commands
- Tab completion support for target branch in `apply` command

### Tests (tests/test_stash.py)
- 10 comprehensive test cases covering:
  - Stash creation with/without messages
  - Empty change detection
  - Multi-branch stash listing
  - Same/cross-worktree stash application
  - Error handling (nonexistent branch, invalid stash ref)
  - Specific stash reference application

## Test Results

All tests pass:
```
tests/test_stash.py::test_stash_save_with_message PASSED
tests/test_stash.py::test_stash_save_without_message PASSED
tests/test_stash.py::test_stash_save_no_changes PASSED
tests/test_stash.py::test_stash_list_empty PASSED
tests/test_stash.py::test_stash_list_multiple_branches PASSED
tests/test_stash.py::test_stash_apply_to_same_worktree PASSED
tests/test_stash.py::test_stash_apply_to_different_worktree PASSED
tests/test_stash.py::test_stash_apply_nonexistent_branch PASSED
tests/test_stash.py::test_stash_apply_invalid_stash_ref PASSED
tests/test_stash.py::test_stash_apply_specific_ref PASSED
```

## Example Usage

```bash
# Save changes in current worktree
cw stash save "Work in progress on auth feature"

# List all stashes grouped by branch
cw stash list

# Apply stash to a different worktree
cw stash apply feature-branch --stash stash@{0}

# Apply most recent stash (default)
cw stash apply feature-branch
```

## Resolves

- TODO: MEDIUM priority - Worktree-aware stash management

## Test Plan

- [x] Run full test suite locally (`uv run pytest`)
- [x] All stash tests pass (10/10)
- [x] Pre-commit hooks pass (ruff, mypy)
- [ ] GitHub Actions pass on all platforms (Ubuntu/macOS × Python 3.11/3.12)