### PR TITLE
feat: Add cw stats command for usage analytics

### DIFF
--- a/src/claude_worktree/cli.py
+++ b/src/claude_worktree/cli.py
@@ -554,6 +554,30 @@ def diff(
 
 
 @app.command()
+def stats() -> None:
+    """
+    Display usage analytics for worktrees.
+
+    Shows comprehensive statistics about your worktrees:
+    - Total worktrees count and status distribution
+    - Age statistics (average, oldest, newest)
+    - Commit activity across worktrees
+    - Top 5 oldest worktrees
+    - Top 5 most active worktrees by commit count
+
+    Example:
+        cw stats
+    """
+    try:
+        from .core import show_stats
+
+        show_stats()
+    except ClaudeWorktreeError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@app.command()
 def upgrade() -> None:
     """
     Upgrade claude-worktree to the latest version.

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,253 @@
+"""Tests for stats functionality."""
+
+import subprocess
+import time
+from pathlib import Path
+
+from claude_worktree.core import format_age, show_stats
+
+
+def test_show_stats_no_worktrees(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test stats display with no feature worktrees."""
+    monkeypatch.chdir(temp_git_repo)
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    assert "No feature worktrees found" in captured.out
+
+
+def test_show_stats_single_worktree(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test stats display with a single worktree."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create a feature worktree
+    feature_path = temp_git_repo.parent / "feature"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-branch", str(feature_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    # Check for statistics sections
+    assert "Worktree Statistics" in captured.out or "📊" in captured.out
+    assert "Overview:" in captured.out
+    assert "Total worktrees: 1" in captured.out
+    assert "feature-branch" in captured.out
+
+
+def test_show_stats_multiple_worktrees(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test stats display with multiple worktrees."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create multiple feature worktrees
+    feature1_path = temp_git_repo.parent / "feature1"
+    feature2_path = temp_git_repo.parent / "feature2"
+    feature3_path = temp_git_repo.parent / "feature3"
+
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-1", str(feature1_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-2", str(feature2_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-3", str(feature3_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    # Should show 3 worktrees
+    assert "Total worktrees: 3" in captured.out
+
+
+def test_show_stats_age_statistics(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test that age statistics are displayed."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create a feature worktree
+    feature_path = temp_git_repo.parent / "feature"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-branch", str(feature_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    # Should show age statistics section
+    assert "Age Statistics:" in captured.out
+    assert "Average age:" in captured.out
+    assert "Oldest:" in captured.out
+    assert "Newest:" in captured.out
+
+
+def test_show_stats_commit_statistics(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test that commit statistics are displayed."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create a feature worktree with commits
+    feature_path = temp_git_repo.parent / "feature"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature-branch", str(feature_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    # Make a commit in the feature worktree
+    test_file = feature_path / "test.txt"
+    test_file.write_text("test")
+    subprocess.run(["git", "add", "test.txt"], cwd=feature_path, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "test commit"], cwd=feature_path, capture_output=True, check=True
+    )
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    # Should show commit statistics
+    assert "Commit Statistics:" in captured.out
+    assert "Total commits" in captured.out
+    assert "Average commits" in captured.out
+
+
+def test_show_stats_status_distribution(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test that status distribution is shown."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create clean worktree
+    clean_path = temp_git_repo.parent / "clean"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "clean-branch", str(clean_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+
+    # Create modified worktree
+    modified_path = temp_git_repo.parent / "modified"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "modified-branch", str(modified_path), "HEAD"],
+        cwd=temp_git_repo,
+        capture_output=True,
+        check=True,
+    )
+    (modified_path / "test.txt").write_text("modified")
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    # Should show status distribution
+    assert "Status:" in captured.out
+    assert "clean" in captured.out
+
+
+def test_show_stats_oldest_worktrees(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test that oldest worktrees are listed."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create worktrees
+    for i in range(3):
+        feature_path = temp_git_repo.parent / f"feature{i}"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", f"feature-{i}", str(feature_path), "HEAD"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        # Sleep briefly to ensure different timestamps
+        time.sleep(0.1)
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    # Should show oldest worktrees section
+    assert "Oldest Worktrees:" in captured.out
+
+
+def test_show_stats_most_active_worktrees(temp_git_repo: Path, monkeypatch, capsys) -> None:
+    """Test that most active worktrees are listed."""
+    monkeypatch.chdir(temp_git_repo)
+
+    # Create worktrees with different commit counts
+    for i in range(2):
+        feature_path = temp_git_repo.parent / f"feature{i}"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", f"feature-{i}", str(feature_path), "HEAD"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        # Make commits
+        for j in range(i + 1):
+            test_file = feature_path / f"test{j}.txt"
+            test_file.write_text(f"test {j}")
+            subprocess.run(
+                ["git", "add", f"test{j}.txt"], cwd=feature_path, capture_output=True, check=True
+            )
+            subprocess.run(
+                ["git", "commit", "-m", f"commit {j}"],
+                cwd=feature_path,
+                capture_output=True,
+                check=True,
+            )
+
+    show_stats()
+
+    captured = capsys.readouterr()
+    # Should show most active worktrees section
+    assert "Most Active Worktrees" in captured.out
+
+
+def test_format_age_hours() -> None:
+    """Test format_age for hours."""
+    assert format_age(0.5) == "12h ago"
+    assert format_age(0.04) == "just now"  # Less than 1 hour shows as "just now"
+    assert format_age(0.0) == "just now"
+
+
+def test_format_age_days() -> None:
+    """Test format_age for days."""
+    assert format_age(1.5) == "1d ago"
+    assert format_age(3.0) == "3d ago"
+    assert format_age(6.9) == "6d ago"
+
+
+def test_format_age_weeks() -> None:
+    """Test format_age for weeks."""
+    assert format_age(7.0) == "1w ago"
+    assert format_age(14.0) == "2w ago"
+    assert format_age(21.0) == "3w ago"
+
+
+def test_format_age_months() -> None:
+    """Test format_age for months."""
+    assert format_age(30.0) == "1mo ago"
+    assert format_age(60.0) == "2mo ago"
+    assert format_age(180.0) == "6mo ago"
+
+
+def test_format_age_years() -> None:
+    """Test format_age for years."""
+    assert format_age(365.0) == "1y ago"
+    assert format_age(730.0) == "2y ago"


### PR DESCRIPTION
## Summary

Implements comprehensive usage analytics for worktrees with the `cw stats` command.

## Key Features

- **Overview statistics**: Total worktrees count and status distribution (clean, modified, active, stale)
- **Age statistics**: Average, oldest, and newest worktree ages
- **Commit statistics**: Total commits, average commits per worktree, maximum commits
- **Top 5 oldest worktrees**: Shows worktrees sorted by age with human-readable timestamps
- **Top 5 most active worktrees**: Shows worktrees sorted by commit count
- **Colored output**: Status icons and colors for visual clarity
- **Human-readable age format**: Displays ages as "12h ago", "3d ago", "2w ago", "6mo ago", "1y ago"

## Implementation Details

### Core Functions (`src/claude_worktree/core.py`)
- **`show_stats()`**: Main statistics display function
  - Collects data from all worktrees using `parse_worktrees()`
  - Calculates age based on directory modification time
  - Counts commits using `git rev-list --count`
  - Groups and displays statistics in multiple sections
  - Shows top 5 lists sorted by age and commit count
- **`format_age(age_days)`**: Helper function to format age
  - Converts float days to human-readable strings
  - Formats: hours (< 1 day), days (< 7 days), weeks (< 30 days), months (< 365 days), years (≥ 365 days)

### CLI Command (`src/claude_worktree/cli.py`)
- Added `cw stats` command with comprehensive documentation
- No arguments or options needed (simple invocation)

### Tests (`tests/test_stats.py`)
- 13 comprehensive test cases covering:
  - Empty repository (no worktrees)
  - Single and multiple worktrees
  - Age statistics display
  - Commit statistics display
  - Status distribution
  - Oldest worktrees list
  - Most active worktrees list
  - Age formatting edge cases (hours, days, weeks, months, years)

## Example Output

```
📊 Worktree Statistics

Overview:
  Total worktrees: 5
  Status: 3 clean, 1 modified, 1 active, 0 stale

Age Statistics:
  Average age: 12.3 days
  Oldest: 45.2 days
  Newest: 2.1 days

Commit Statistics:
  Total commits across all worktrees: 127
  Average commits per worktree: 25.4
  Most commits in a worktree: 58

Oldest Worktrees:
  ○ legacy-refactor              45d ago
  ○ feature-api-v2               32d ago
  ◉ hotfix-auth                  18d ago
  ○ update-docs                  12d ago
  ● feature-new-ui               2d ago

Most Active Worktrees (by commits):
  ○ feature-api-v2               58 commits
  ◉ hotfix-auth                  34 commits
  ○ legacy-refactor              21 commits
  ● feature-new-ui               8 commits
  ○ update-docs                  6 commits
```

## Test Results

All tests pass:
```
tests/test_stats.py::test_show_stats_no_worktrees PASSED
tests/test_stats.py::test_show_stats_single_worktree PASSED
tests/test_stats.py::test_show_stats_multiple_worktrees PASSED
tests/test_stats.py::test_show_stats_age_statistics PASSED
tests/test_stats.py::test_show_stats_commit_statistics PASSED
tests/test_stats.py::test_show_stats_status_distribution PASSED
tests/test_stats.py::test_show_stats_oldest_worktrees PASSED
tests/test_stats.py::test_show_stats_most_active_worktrees PASSED
tests/test_stats.py::test_format_age_hours PASSED
tests/test_stats.py::test_format_age_days PASSED
tests/test_stats.py::test_format_age_weeks PASSED
tests/test_stats.py::test_format_age_months PASSED
tests/test_stats.py::test_format_age_years PASSED
```

## Resolves

- TODO: LOW priority - Usage analytics (`cw stats`)

## Test Plan

- [x] Run full test suite locally (`uv run pytest`)
- [x] All stats tests pass (13/13)
- [x] Pre-commit hooks pass (ruff, mypy)
- [ ] GitHub Actions pass on all platforms (Ubuntu/macOS × Python 3.11/3.12)