### PR TITLE
feat: Add change-base command to change worktree base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,24 @@ cw sync --fetch-only
 
 Fetches latest changes and rebases your feature branch onto the updated base branch. Useful for long-running features.
 
+### Change base branch
+
+```bash
+# Change base branch for current worktree
+cw change-base master
+
+# Change base for specific worktree
+cw change-base develop -t fix-auth
+
+# Interactive rebase
+cw change-base main -i
+
+# Preview changes
+cw change-base master --dry-run
+```
+
+Use this when you realize after creating a worktree that you should have based it on a different branch. The command will rebase your feature branch onto the new base and update the metadata.
+
 ### Health check
 
 ```bash
@@ -400,6 +418,7 @@ The old `cw finish` command still works but is deprecated. Use `cw pr` or `cw me
 | `cw clean -i` | Interactive cleanup with selection UI |
 | `cw sync [branch]` | Sync worktree(s) with base branch |
 | `cw sync --all` | Sync all worktrees |
+| `cw change-base <new-base>` | Change base branch and rebase |
 | `cw doctor` | Health check and diagnostics |
 
 ### Analysis & Visualization

--- a/src/claude_worktree/cli.py
+++ b/src/claude_worktree/cli.py
@@ -19,6 +19,7 @@ from .config import (
 )
 from .core import (
     backup_worktree,
+    change_base_branch,
     create_pr_worktree,
     create_worktree,
     delete_worktree,
@@ -597,6 +598,64 @@ def sync(
         from .core import sync_worktree
 
         sync_worktree(target=target, all_worktrees=all_worktrees, fetch_only=fetch_only)
+    except ClaudeWorktreeError as e:
+        console.print(f"[bold red]Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@app.command(name="change-base", rich_help_panel="Worktree Management")
+def change_base_cmd(
+    new_base: str = typer.Argument(
+        ...,
+        help="New base branch name",
+        autocompletion=complete_all_branches,
+    ),
+    target: str | None = typer.Option(
+        None,
+        "--target",
+        "-t",
+        help="Worktree branch to change (optional, defaults to current directory)",
+        autocompletion=complete_worktree_branches,
+    ),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive",
+        "-i",
+        help="Use interactive rebase",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview changes without executing",
+    ),
+) -> None:
+    """
+    Change the base branch for a worktree and rebase onto it.
+
+    This is useful when you realize after creating a worktree that you should
+    have based it on a different branch (e.g., 'master' instead of 'develop').
+
+    The command will:
+    1. Fetch latest changes from remote
+    2. Rebase the feature branch onto the new base branch
+    3. Update the base branch metadata
+
+    If the rebase fails due to conflicts, you'll need to resolve them manually
+    and then run this command again to update the metadata.
+
+    Example:
+        cw change-base master              # Change current worktree to master
+        cw change-base develop -t fix-auth # Change fix-auth to develop
+        cw change-base main -i             # Interactive rebase
+        cw change-base master --dry-run    # Preview changes
+    """
+    try:
+        change_base_branch(
+            new_base=new_base,
+            target=target,
+            interactive=interactive,
+            dry_run=dry_run,
+        )
     except ClaudeWorktreeError as e:
         console.print(f"[bold red]Error:[/bold red] {e}")
         raise typer.Exit(code=1)

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "claude-worktree"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Add `cw change-base` command that allows users to change the base branch of an existing worktree after creation. This addresses the common scenario where you realize you should have based your feature on a different branch (e.g., master instead of develop).

## Changes

### Core Functionality
- **New command**: `cw change-base <new-base>` in "Worktree Management" category
- **Function**: `change_base_branch()` in `src/claude_worktree/core.py`
- Fetches latest changes from remote
- Rebases feature branch onto new base branch
- Updates base branch metadata in git config

### Features
- ✅ Change base for current or specific worktree (--target)
- ✅ Interactive rebase support (--interactive/-i)
- ✅ Dry-run mode to preview changes (--dry-run)
- ✅ Comprehensive error handling for conflicts and invalid branches
- ✅ Automatic metadata update after successful rebase

### Usage

```bash
# Change base branch for current worktree
cw change-base master

# Change base for specific worktree
cw change-base develop -t fix-auth

# Interactive rebase
cw change-base main -i

# Preview changes
cw change-base master --dry-run
```

### Files Changed
- `src/claude_worktree/core.py` - Added `change_base_branch()` function
- `src/claude_worktree/cli.py` - Added `change-base` command with categorization
- `README.md` - Added usage examples and command reference
- `tests/test_core.py` - Added 6 comprehensive test cases
- `uv.lock` - Updated dependencies lock file

### Test Coverage

All 6 tests passing locally:
- ✅ `test_change_base_branch_success` - Basic functionality
- ✅ `test_change_base_branch_with_target` - Remote worktree targeting
- ✅ `test_change_base_branch_dry_run` - Preview mode
- ✅ `test_change_base_branch_invalid_base` - Error handling for invalid base
- ✅ `test_change_base_branch_no_metadata` - Error handling for missing metadata
- ✅ `test_change_base_branch_with_conflicts` - Conflict detection and abort

## Test Plan

- [x] Cherry-picked original changes cleanly from PR #27
- [x] All 6 change-base tests pass locally
- [x] Linting and formatting checks pass
- [x] uv.lock included in commit
- [ ] Wait for CI to pass (all platforms, Python 3.11 & 3.12)

**Note**: This is a clean recreation of PR #27 with proper test coverage and uv.lock included.