### PR TITLE
feat: Change default AI tool preset to claude-yolo

### DIFF
--- a/src/claude_worktree/config.py
+++ b/src/claude_worktree/config.py
@@ -25,6 +25,7 @@ AI_TOOL_PRESETS = {
     "no-op": [],
     # Claude Code
     "claude": ["claude"],
+    "claude-yolo": ["claude", "--yolo"],
     # Codex
     "codex": ["codex"],
     # Happy (mobile-enabled Claude Code)
@@ -36,7 +37,7 @@ AI_TOOL_PRESETS = {
 
 DEFAULT_CONFIG = {
     "ai_tool": {
-        "command": "claude",  # Command name or preset name
+        "command": "claude-yolo",  # Command name or preset name
         "args": [],  # Additional arguments
     },
     "launch": {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,7 +107,7 @@ def test_save_config_creates_directory(tmp_path: Path, monkeypatch) -> None:
 def test_get_ai_tool_command_default(temp_config_dir: Path) -> None:
     """Test getting default AI tool command."""
     cmd = get_ai_tool_command()
-    assert cmd == ["claude"]
+    assert cmd == ["claude", "--yolo"]
 
 
 def test_get_ai_tool_command_custom(temp_config_dir: Path) -> None:
@@ -270,8 +270,8 @@ def test_show_config(temp_config_dir: Path) -> None:
     output = show_config()
 
     # Should contain key information
-    assert "AI Tool: claude" in output
-    assert "Effective command: claude" in output
+    assert "AI Tool: claude-yolo" in output
+    assert "Effective command: claude --yolo" in output
     assert "Default base branch: main" in output
     assert "Config file:" in output
 
@@ -341,6 +341,7 @@ def test_ai_tool_presets_defined() -> None:
     expected_presets = [
         "no-op",
         "claude",
+        "claude-yolo",
         "codex",
         "happy",
         "happy-codex",
@@ -353,6 +354,15 @@ def test_ai_tool_presets_defined() -> None:
         # no-op preset can be empty
         if preset != "no-op":
             assert len(AI_TOOL_PRESETS[preset]) > 0
+
+
+def test_claude_preset_commands() -> None:
+    """Test that Claude presets generate correct commands."""
+    # Test basic claude
+    assert AI_TOOL_PRESETS["claude"] == ["claude"]
+
+    # Test claude-yolo (with --yolo flag)
+    assert AI_TOOL_PRESETS["claude-yolo"] == ["claude", "--yolo"]
 
 
 def test_happy_preset_commands() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "claude-worktree"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Change the default AI tool preset from `claude` to `claude-yolo` to enable YOLO mode by default. This provides a more streamlined developer experience by bypassing permission prompts for common operations.

## Changes

- **config.py**: Add `claude-yolo` preset to `AI_TOOL_PRESETS` dictionary
- **config.py**: Update `DEFAULT_CONFIG` to use `claude-yolo` as default command  
- **test_config.py**: Add `test_claude_preset_commands()` to verify Claude presets
- **test_config.py**: Update test expectations to reflect new default behavior
- **uv.lock**: Include updated lock file with dependencies

## Testing

All 28 config tests pass:
- ✅ New preset is correctly defined
- ✅ Default command resolves to `["claude", "--yolo"]`
- ✅ Effective command shown in config output
- ✅ All existing tests updated for new default

## Backward Compatibility

Users who prefer the non-YOLO mode can still use it by:
```bash
cw config use-preset claude
```

This is a clean extraction of the feature from PR #25, without the backup/restore code that was causing merge conflicts.